### PR TITLE
fix: Error void variable org-src-mode

### DIFF
--- a/flycheck-nim.el
+++ b/flycheck-nim.el
@@ -107,7 +107,7 @@ See http://nim-lang.org"
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
   :modes (nim-mode nimrod-mode)
-  :predicate (lambda () (not org-src-mode)))
+  :predicate (lambda () (not (bound-and-true-p org-src-mode))))
 
 (add-to-list 'flycheck-checkers 'nim)
 


### PR DESCRIPTION
Why?:
- Running different Flycheck commands result in the error "void variable org-src-mode" and thus should be fixed.

This change addresses the need by:
- check if org-src-mode is bound first before trying to retrieve its value